### PR TITLE
Bundled ls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 node_modules
 .vscode-test/
 *.vsix
+bin

--- a/README.md
+++ b/README.md
@@ -1,22 +1,31 @@
 # Die Deutsche Programmiersprache für Visual Studio Code
 ## Funktionen
 
-|||
-|--|--|
-|![image](https://github.com/DDP-Projekt/vscode-ddp/assets/26361108/114484b8-58c3-480b-a2b3-c2447bfeb53f)Syntax highlighting (.ddp Dateien)|![image](https://github.com/DDP-Projekt/vscode-ddp/assets/26361108/1367aa51-e873-4492-b493-edb25e1a2bf3)Tooltips|
-|![image](https://github.com/DDP-Projekt/vscode-ddp/assets/26361108/34a5f757-2777-4618-a0be-95dc2595223e)Befehle|![image](https://github.com/DDP-Projekt/vscode-ddp/assets/26361108/38975815-477e-4c2e-b43d-a0930c54721e)Vervollständigung|
-|![image](https://github.com/DDP-Projekt/vscode-ddp/assets/26361108/a53dfbd9-c200-446d-abbd-c1e0843696dc)Fehlerbericht|![image](https://github.com/DDP-Projekt/vscode-ddp/assets/26361108/5dff6294-fa94-44fb-828a-e4cb76ff1df3)Goto/Peek Definition|
-|||
+|                                                                                                                                            |                                                                                                                              |
+| ------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| ![image](https://github.com/DDP-Projekt/vscode-ddp/assets/26361108/114484b8-58c3-480b-a2b3-c2447bfeb53f)Syntax highlighting (.ddp Dateien) | ![image](https://github.com/DDP-Projekt/vscode-ddp/assets/26361108/1367aa51-e873-4492-b493-edb25e1a2bf3)Tooltips             |
+| ![image](https://github.com/DDP-Projekt/vscode-ddp/assets/26361108/34a5f757-2777-4618-a0be-95dc2595223e)Befehle                            | ![image](https://github.com/DDP-Projekt/vscode-ddp/assets/26361108/38975815-477e-4c2e-b43d-a0930c54721e)Vervollständigung    |
+| ![image](https://github.com/DDP-Projekt/vscode-ddp/assets/26361108/a53dfbd9-c200-446d-abbd-c1e0843696dc)Fehlerbericht                      | ![image](https://github.com/DDP-Projekt/vscode-ddp/assets/26361108/5dff6294-fa94-44fb-828a-e4cb76ff1df3)Goto/Peek Definition |
+|                                                                                                                                            |                                                                                                                              |
 
 ## Installation
-Für alle features außer Schlüsselwort highlighting muss man den Sprachserver [DDP-LS](https://github.com/DDP-Projekt/DDPLS) installiert haben!
 
-### Release version
 Im Erweiterungen Menü in vscode nach DDP suchen und installieren oder über diesen link: https://marketplace.visualstudio.com/items?itemName=DDP-Projekt.vscode-ddp
 
+Optional direkt von der [Github Release Seite](https://github.com/DDP-Projekt/vscode-ddp/releases) herunterladen.
+
 ### Developer version
-1. Klonen Sie dieses Repo in den Ordner\
+1. Dieses Repo in den Ordner\
    `%USERPROFILE%\.vscode\extensions` auf Windows\
    `~/.vscode/extensions` auf MacOS\
-   `~/.vscode/extensions` auf Linux
+   `~/.vscode/extensions` auf Linux<br>
+   klonen.
 2. VSCode neustarten.
+
+## Release
+
+1. Version erhöhen
+2. Optional die DDPLS<.exe> binaries in das bin/ Verzeichnis kopieren
+   sollte man das nicht machen muss der Benutzer DDPLS global installiert haben
+3. `vsce package` ausführen für die .vsix Datei (für den Github Release)
+4. `vsce publish` für den Marketplace Release ausführen

--- a/package.json
+++ b/package.json
@@ -78,6 +78,11 @@
 					"default": [],
 					"description": "arguments that are passed to $kddp starte"
 				},
+				"ddp.DDPLS.path": {
+					"type": "string",
+					"default": "",
+					"description": "if present this DDPLS binary is used instead of the one shipped with the extension or the global one"
+				},
 				"ddp.DDPLS.flags": {
 					"type": "array",
 					"default": [],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 import * as langsrv from 'vscode-languageclient/node';
 import * as path from 'path';
 import * as os from 'os';
+import * as fs from 'fs';
 
 let DDPPATH = process.env.DDPPATH;
 
@@ -17,12 +18,20 @@ export function activate(ctx: vscode.ExtensionContext) {
 		out.appendLine("DDPPATH not found\nThis might cause errors in some commands");
 	}
 
+	let commandName = "DDPLS";
+	{
+		let ddplsPath = ctx.asAbsolutePath(path.join('bin', os.platform() === 'win32' ? 'DDPLS.exe' : 'DDPLS'));
+		if (fs.existsSync(ddplsPath)) {
+			commandName = ddplsPath;
+		}
+	}
+
 	let config = vscode.workspace.getConfiguration('ddp');
 	let lsArgs = config.get<string[]>("DDPLS.flags");
 	// DDPLS must be installed and in the PATH
 	let serverOptions: langsrv.ServerOptions = {
-		run: { command: "DDPLS", args: lsArgs },
-		debug: { command: "DDPLS", args: lsArgs }
+		run: { command: commandName, args: lsArgs },
+		debug: { command: commandName, args: lsArgs }
 	};
 
 	let clientOptions: langsrv.LanguageClientOptions = {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,15 +18,21 @@ export function activate(ctx: vscode.ExtensionContext) {
 		out.appendLine("DDPPATH not found\nThis might cause errors in some commands");
 	}
 
+	let config = vscode.workspace.getConfiguration('ddp');
+
 	let commandName = "DDPLS";
-	{
+	if (config.has("DDPLS.path")) {
+		let ddplsPath = config.get<string>("DDPLS.path");
+		if (ddplsPath !== "" && ddplsPath !== undefined) {
+			commandName = ddplsPath;
+		}
+	} else {
 		let ddplsPath = ctx.asAbsolutePath(path.join('bin', os.platform() === 'win32' ? 'DDPLS.exe' : 'DDPLS'));
 		if (fs.existsSync(ddplsPath)) {
 			commandName = ddplsPath;
 		}
 	}
 
-	let config = vscode.workspace.getConfiguration('ddp');
 	let lsArgs = config.get<string[]>("DDPLS.flags");
 	// DDPLS must be installed and in the PATH
 	let serverOptions: langsrv.ServerOptions = {
@@ -63,15 +69,12 @@ export function activate(ctx: vscode.ExtensionContext) {
 			return;
 		}
 
-		let config = vscode.workspace.getConfiguration('ddp');
+		let DDPPATH = "";
 		if (config.has("DDPPATH")) {
-			let ddppath = config.get("DDPPATH");
-			if (ddppath !== "") {
-				DDPPATH = config.get("DDPPATH");
+			let ddppath = config.get<string>("DDPPATH");
+			if (ddppath !== "" && ddppath !== undefined) {
+				DDPPATH = ddppath;
 			}
-		}
-		if (DDPPATH === undefined) {
-			DDPPATH = "";
 		}
 
 		let exe = path.join(DDPPATH, 'bin', os.platform() === 'win32' ? 'kddp.exe' : 'kddp').replace(new RegExp('\\' + path.sep, 'g'), '/');


### PR DESCRIPTION
Mit diesem Commit kann man optional die DDPLS binaries in das bin/ directory packen, um diese mit der extension zu bundlen.
Außerdem kann man in settings.json eine ddp.DDPLS.path Einstellung angeben, falls man eine eigene DDPLS Version benutzen möchte.

Die Extension würde dann so vorgehen:
1. Wenn ddp.DDPLS.path gesetzt ist, diese binary benutzen
2. ansonsten überprüfen ob <extension-dir>/bin/DDPLS<.exe> existiert, und wenn ja diese binary benutzen
3. ansonsten eine globale Installation von DDPLS benutzen (dafür muss DDPLS im PATH sein, so wie es momentan ist)

Das würde es ermöglichen Language Server updates zu veröffentlichen, ohne dass a) Nutzer von Hand die LS Binary herunterladen müssen oder b) wir einen komplett neuen DDP Release machen müssen.
Das wäre sehr praktisch für simple hot-fixes im parser.